### PR TITLE
Update VIPER.podspec, lower deployment target

### DIFF
--- a/VIPER.podspec
+++ b/VIPER.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/CoreKit/VIPER.git', :tag => s.version.to_s }
     s.social_media_url = 'https://twitter.com/tiborbodecs'
 
-    s.ios.deployment_target = '11.0'
+    s.ios.deployment_target = '9.0'
 
     s.swift_version = '5.0'
     s.source_files = 'Sources/**/*'


### PR DESCRIPTION
This set of protocols don't really seem to require target ios 11+. Built with ios 9, works fine